### PR TITLE
Implementa Serilog e observabilidade com Elasticsearch, Kibana e Jaeger

### DIFF
--- a/docker-compose.override.yml
+++ b/docker-compose.override.yml
@@ -1,11 +1,58 @@
 services:
+  elasticsearch:
+    container_name: elasticsearch
+    environment:
+      - node.name=elasticsearch
+      - discovery.type=single-node
+      - bootstrap.memory_lock=true
+      - "ES_JAVA_OPTS=-Xms512m -Xmx512m"
+    ulimits:
+      memlock:
+        soft: -1
+        hard: -1
+    volumes:
+      - es-data:/usr/share/elasticsearch/data
+    ports:
+      - "9200:9200"
+      - "9300:9300"
+    networks:
+      - app-network
+      
+  kibana:
+    container_name: kibana
+    environment:
+      - ELASTICSEARCH_HOSTS=http://elasticsearch:9200
+    ports:
+      - "5601:5601"
+    depends_on:
+      - elasticsearch
+    networks:
+      - app-network
+  
+  jaeger:
+    container_name: jaeger
+    ports:
+      - "4317:4317"
+      - "16686:16686"
+    networks:
+      - app-network
+
   vacationsystemdb:
     container_name: vacationsystemdb
     environment:
       - ACCEPT_EULA=Y
       - MSSQL_SA_PASSWORD=Passw0rd
-    restart: always
     ports:
       - "1433:1433"
     volumes:
       - mssql_vacationsystem:/var/opt/mssql
+    networks:
+      - app-network
+
+networks:
+  app-network:
+    driver: bridge
+
+volumes:
+  es-data:
+    driver: local

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,4 +1,13 @@
 services:
+  elasticsearch:
+    image: docker.elastic.co/elasticsearch/elasticsearch:7.13.3
+
+  kibana:
+    image: docker.elastic.co/kibana/kibana:7.13.3
+
+  jaeger:
+    image: jaegertracing/all-in-one:1.58
+
   vacationsystemdb:
     image: mcr.microsoft.com/mssql/server:2022-latest
 

--- a/src/VacationSystem.API/Extensions/LogExtensions.cs
+++ b/src/VacationSystem.API/Extensions/LogExtensions.cs
@@ -1,0 +1,78 @@
+using OpenTelemetry.Metrics;
+using OpenTelemetry.Resources;
+using OpenTelemetry.Trace;
+using Serilog;
+using Serilog.Exceptions;
+using Serilog.Sinks.Elasticsearch;
+
+namespace VacationSystem.API.Extensions;
+
+public static class LogExtensions
+{
+    public static void AddLog(
+        this IServiceCollection services,
+        IConfiguration configuration,
+        string appName,
+        string appVersion
+    )
+    {
+        services.AddSerilog((_, options) =>
+        {
+            var elasticSearchUri = new Uri(configuration["ElasticSearch:Uri"]!);
+
+            options.WriteTo.Elasticsearch(new ElasticsearchSinkOptions(elasticSearchUri!)
+            {
+                AutoRegisterTemplate = true,
+                IndexFormat = $"{configuration["Elasticsearch:IndexFormatPrefix"]}-{{0:yyyy.MM.dd}}",
+                NumberOfReplicas = 1,
+                NumberOfShards = 2
+            });
+
+            #if DEBUG
+            options.WriteTo.Console();
+            options.MinimumLevel.Debug();
+            #else
+            options.WriteTo.Console(new CompactJsonFormatter());
+            #endif
+
+            options.Enrich.FromLogContext();
+            options.Enrich.WithExceptionDetails();
+        });
+
+        services.AddOpenTelemetry(appName, appVersion);
+    }
+
+    public static void UseLog(this IApplicationBuilder app)
+    {
+        app.UseSerilogRequestLogging();
+    }
+
+    private static void AddOpenTelemetry(
+        this IServiceCollection services,
+        string appName,
+        string appVersion
+    )
+    {
+        services.AddOpenTelemetry()
+            .WithTracing(tracing =>
+            {
+                tracing.SetResourceBuilder(ResourceBuilder.CreateDefault().AddService(appName, appVersion));
+                tracing.AddAspNetCoreInstrumentation();
+                tracing.AddHttpClientInstrumentation();
+                tracing.AddSqlClientInstrumentation();
+                tracing.AddOtlpExporter();
+                tracing.AddConsoleExporter();
+            })
+            .WithMetrics(metrics =>
+            {
+                metrics.SetResourceBuilder(ResourceBuilder.CreateDefault().AddService(appName, appVersion));
+
+                metrics.AddRuntimeInstrumentation();
+                metrics.AddAspNetCoreInstrumentation();
+                metrics.AddHttpClientInstrumentation();
+
+                metrics.AddOtlpExporter();
+                metrics.AddConsoleExporter();
+            });
+    }
+}

--- a/src/VacationSystem.API/Program.cs
+++ b/src/VacationSystem.API/Program.cs
@@ -1,5 +1,7 @@
+using System.Reflection;
 using Carter;
 using Microsoft.OpenApi.Models;
+using VacationSystem.API.Extensions;
 using VacationSystem.API.Infrastructure;
 using VacationSystem.API.Token;
 using VacationSystem.Application;
@@ -7,6 +9,10 @@ using VacationSystem.Application.Common.Security.Tokens;
 using VacationSystem.Application.Infrastructure.Persistence.Extensions;
 
 const string AUTHENTICATION_TYPE = "Bearer";
+
+var assemblyName = Assembly.GetExecutingAssembly().GetName();
+var appName = assemblyName.Name;
+var appVersion = assemblyName.Version?.ToString();
 
 var builder = WebApplication.CreateBuilder(args);
 
@@ -58,7 +64,8 @@ builder.Services
     .AddProblemDetails()
     .AddCarter()
     .AddScoped<ITokenProvider, HttpContextTokenValue>()
-    .AddHttpContextAccessor();
+    .AddHttpContextAccessor()
+    .AddLog(builder.Configuration, appName!, appVersion!);
 
 var app = builder.Build();
 
@@ -75,6 +82,7 @@ if (app.Environment.IsDevelopment())
 app.UseCors();
 app.MapCarter();
 app.UseExceptionHandler(options => { });
+app.UseLog();
 
 await UpdateDatabase();
 

--- a/src/VacationSystem.API/VacationSystem.API.csproj
+++ b/src/VacationSystem.API/VacationSystem.API.csproj
@@ -14,6 +14,20 @@
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>
     <PackageReference Include="Swashbuckle.AspNetCore" Version="6.6.2" />
+    <PackageReference Include="Npgsql.OpenTelemetry" Version="10.0.0" />
+        
+        <PackageReference Include="OpenTelemetry.Exporter.Console" Version="1.9.0" />
+        <PackageReference Include="OpenTelemetry.Exporter.OpenTelemetryProtocol" Version="1.9.0" />
+        <PackageReference Include="OpenTelemetry.Extensions.Hosting" Version="1.9.0" />
+        <PackageReference Include="OpenTelemetry.Instrumentation.AspNetCore" Version="1.9.0" />
+        <PackageReference Include="OpenTelemetry.Instrumentation.Http" Version="1.9.0" />
+        <PackageReference Include="OpenTelemetry.Instrumentation.Runtime" Version="1.9.0" />
+        <PackageReference Include="OpenTelemetry.Instrumentation.SqlClient" Version="1.9.0-beta.1" />
+        <PackageReference Include="Serilog.AspNetCore" Version="8.0.2" />
+        <PackageReference Include="Serilog.Enrichers.Context" Version="4.6.5" />
+        <PackageReference Include="Serilog.Exceptions" Version="8.4.0" />
+        <PackageReference Include="Serilog.Sinks.Elasticsearch" Version="10.0.0" />
+        <PackageReference Include="Serilog.Sinks.OpenTelemetry" Version="4.0.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/VacationSystem.API/appsettings.Development.json
+++ b/src/VacationSystem.API/appsettings.Development.json
@@ -15,12 +15,16 @@
     }
   },
   "RabbitMQ": {
-      "HostName": "localhost",
-      "Port": 5672,
-      "UserName": "guest",
-      "Password": "guest",
-      "VirtualHost": "/",
-      "ExchangeName": "vacation_system_exchange",
-      "QueueName": "vacation_system_queue"
-    }
+    "HostName": "localhost",
+    "Port": 5672,
+    "UserName": "guest",
+    "Password": "guest",
+    "VirtualHost": "/",
+    "ExchangeName": "vacation_system_exchange",
+    "QueueName": "vacation_system_queue"
+  },
+  "Elasticsearch": {
+    "Uri": "http://localhost:9200",
+    "IndexFormatPrefix": "vacationsystem-backend"
+  }
 }

--- a/src/VacationSystem.API/appsettings.json
+++ b/src/VacationSystem.API/appsettings.json
@@ -5,14 +5,5 @@
       "Microsoft.AspNetCore": "Warning"
     }
   },
-  "AllowedHosts": "*",
-  "RabbitMQ": {
-    "HostName": "localhost",
-    "Port": 5672,
-    "UserName": "guest",
-    "Password": "guest",
-    "VirtualHost": "/",
-    "ExchangeName": "vacation_system_exchange",
-    "QueueName": "vacation_system_queue"
-  }
+  "AllowedHosts": "*"
 }

--- a/src/VacationSystem.Application/ConfigureServices.cs
+++ b/src/VacationSystem.Application/ConfigureServices.cs
@@ -76,7 +76,7 @@ public static class DependencyInjection
     private static void AddRabbitMQ(IServiceCollection services, IConfiguration configuration)
     {
         services.Configure<RabbitMQSettings>(
-    configuration.GetSection("RabbitMQ"));
+        configuration.GetSection("RabbitMQ"));
         services.AddSingleton<IRabbitMQService, RabbitMQService>();
     }
 


### PR DESCRIPTION
Adiciona serviços de observabilidade no docker-compose, configura OpenTelemetry e Serilog, atualiza o Program.cs e appsettings, e inclui dependências necessárias no VacationSystem.API.csproj.